### PR TITLE
RSS Implementation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "http://localhost:1313/"
+baseURL: "https://nullneu.org/"
 languageCode: "en-us"
 title: "Null NEU"
 enableRobotsTXT: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "/"
+baseURL: "http://localhost:1313/"
 languageCode: "en-us"
 title: "Null NEU"
 enableRobotsTXT: true

--- a/layouts/_default/blog.rss.xml
+++ b/layouts/_default/blog.rss.xml
@@ -1,0 +1,59 @@
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName  = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+{{- $pages = $pctx.RegularPages }}
+{{- else }}
+{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | transform.XMLEscape | safeHTML }}{{ printf " - %d minute read\n" .ReadingTime }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/_default/blog.rss.xml
+++ b/layouts/_default/blog.rss.xml
@@ -52,7 +52,11 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | transform.XMLEscape | safeHTML }}{{ printf " - %d minute read\n" .ReadingTime }}</description>
+      <description>
+        {{ .Summary | transform.XMLEscape | safeHTML }}
+        &lt;br&gt;&lt;br&gt;
+        {{ printf "(%d minute read)" .ReadingTime }}
+      </description>
     </item>
     {{- end }}
   </channel>

--- a/layouts/_default/events.rss.xml
+++ b/layouts/_default/events.rss.xml
@@ -1,0 +1,59 @@
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName  = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+{{- $pages = $pctx.RegularPages }}
+{{- else }}
+{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Params.eventLink }}</link>
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Params.eventLink }}</guid>
+      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/_default/events.rss.xml
+++ b/layouts/_default/events.rss.xml
@@ -53,7 +53,9 @@
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Params.eventLink }}</guid>
       <description>
-        Event date: {{ .Params.eventDate | time | time.Format "Mon, 02 Jan 2006 at 3:04 PM" }}&lt;br&gt;{{ .Summary | transform.XMLEscape | safeHTML }}
+        Event date: {{ .Params.eventDate | time | time.Format "Mon, 02 Jan 2006 at 3:04 PM" }}
+        &lt;br&gt;&lt;br&gt;
+        {{ .Summary | transform.XMLEscape | safeHTML }}
       </description>
     </item>
     {{- end }}

--- a/layouts/_default/events.rss.xml
+++ b/layouts/_default/events.rss.xml
@@ -52,7 +52,9 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Params.eventLink }}</guid>
-      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+      <description>
+        Event date: {{ .Params.eventDate | time | time.Format "Mon, 02 Jan 2006 at 3:04 PM" }}&lt;br&gt;{{ .Summary | transform.XMLEscape | safeHTML }}
+      </description>
     </item>
     {{- end }}
   </channel>


### PR DESCRIPTION
Fixes #22 

## Overview
Implementation of the built-in Hugo RSS reader. Currently, the blog and events sections are able to be imported into an RSS reader via the links https://nullneu.org/blog/index.xml and https://nullneu.org/events/index.xml respectively. Tested on Akregator (KDE) and QuiteRSS readers.

## Changes
- BaseURL: changed to https://nullneu.org/, was previously "/"
  - This is recommended by pretty much everyone for deploying Hugo. Using "/" for the baseURL is recommended only for testing. RSS does not work with relative links, you can read more [here.](https://www.jessesquires.com/blog/2021/06/06/rss-feeds-jekyll-and-absolute-versus-relative-urls/)
- Added blog.rss.xml and events.rss.xml
  - These files serve as templates for the RSS feed, more can be created in the future using the template (e.g. careers.rss.xml)

## Screenshots
Blogs feed in Akregator RSS reader
![image](https://github.com/user-attachments/assets/40ab5bbb-aa31-4285-93fb-c49f976ea41f)

Events feed in QuiteRSS reader
![image](https://github.com/user-attachments/assets/4145448a-b6ca-446c-9a9c-388486a05126)

## To-do
- Add a button at the top of the webpage to reveal the RSS feed link for users
- Potentially add a clickable hyperlink in the article body?
  - Currently, clicking on the title of the article will bring you to the LinkedIn page or full article
- Mark past events as completed
- Configure Hugo to not generate index.xml files for sections that don't have RSS feeds, like teams, tools, careers, etc.
