### PR TITLE
Update Project URL for Hades CTF

### DIFF
--- a/content/projects/hades.md
+++ b/content/projects/hades.md
@@ -3,6 +3,6 @@ title: "Hades"
 date: 2024-08-23T23:53:40-04:00
 draft: false
 summary: "Hades is a roleplay + jeopardy style CTF hosted by nullNEU."
-link: "https://github.com/nullNEU/hades"
+link: "https://github.com/nullNEU/hades-ctf-2024"
 ---
 


### PR DESCRIPTION
The project URL for Hades CTF on the `/projects` page now points to the appropriate GitHub repository.